### PR TITLE
feat(search-multiple-indexers): return first found

### DIFF
--- a/packages/api/module.d.ts
+++ b/packages/api/module.d.ts
@@ -1,1 +1,2 @@
 declare module 'scandirectory';
+declare module 'xml2json-light';

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,8 @@
     "scandirectory": "^5.3.0",
     "transmission-client": "^1.0.0",
     "typeorm": "^0.2.24",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "xml2json-light": "^1.0.6"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.0.0",

--- a/packages/api/src/modules/jackett/jackett.dto.ts
+++ b/packages/api/src/modules/jackett/jackett.dto.ts
@@ -38,3 +38,47 @@ export class JackettFormattedResult {
   @Field((_type) => [String]) public normalizedTitle!: string[];
   @Field((_type) => BigInt) public size!: BigInt;
 }
+
+export interface JackettIndexer {
+  id: string;
+  configured: boolean;
+  title: string;
+  description: string;
+  link: string;
+  language: string;
+  type: string;
+  caps: {
+    server: {
+      title: string;
+    };
+    searching: {
+      search: {
+        available: 'yes' | 'no';
+        supportedParams: string;
+      };
+      tv: {
+        available: 'yes' | 'no';
+        supportedParams: string;
+      };
+      movie: {
+        available: 'yes' | 'no';
+        supportedParams: string;
+      };
+      music: {
+        available: 'yes' | 'no';
+        supportedParams: '';
+      };
+      audio: {
+        available: 'yes' | 'no';
+        supportedParams: string;
+      };
+    };
+    categories: {
+      category: Array<{
+        id: string;
+        name: string;
+        subcat?: Array<{ id: string; name: string }>;
+      }>;
+    };
+  };
+}

--- a/packages/api/src/utils/first-promise-resolve.ts
+++ b/packages/api/src/utils/first-promise-resolve.ts
@@ -1,0 +1,11 @@
+function invert<TResult>(
+  promise: Promise<TResult[] | TResult>
+): Promise<TResult> {
+  return new Promise((res, rej) => promise.then(rej, res));
+}
+
+export function firstOf<TResult>(
+  promises: Array<Promise<TResult>>
+): Promise<TResult> {
+  return invert<TResult>(Promise.all(promises.map((p) => invert<TResult>(p))));
+}

--- a/packages/api/yarn.lock
+++ b/packages/api/yarn.lock
@@ -6568,6 +6568,11 @@ xml2js@^0.4.17:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
+xml2json-light@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/xml2json-light/-/xml2json-light-1.0.6.tgz#111687710a2b01fbd2fe18f418adf511de547f34"
+  integrity sha1-ERaHcQorAfvS/hj0GK31Ed5UfzQ=
+
 xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"


### PR DESCRIPTION
linked to #58 

When you have multiple indexers added into jackett, it will send search into each of the indexers but will return the first downloable results found in any indexer.

It can still be improved with adding a filter on quality, so it won't stops search until the good quality has been found.