### PR TITLE
feat: Add better truncation & tooltips to the results table

### DIFF
--- a/packages/web/components/manual-search/jackett-results-table.tsx
+++ b/packages/web/components/manual-search/jackett-results-table.tsx
@@ -50,9 +50,7 @@ export function JackettResultsTable({
         showTitle: false,
       },
       render: (row: JackettFormattedResult) => (
-        <Popover content={row.title}>
-          {row.title}
-        </Popover>
+        <Popover content={row.title}>{row.title}</Popover>
       ),
     },
     {

--- a/packages/web/components/manual-search/jackett-results-table.tsx
+++ b/packages/web/components/manual-search/jackett-results-table.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import prettySize from 'prettysize';
-import { truncate, pick } from 'lodash';
+import { pick } from 'lodash';
 import { PureQueryOptions } from '@apollo/client';
 
 import { Table, Popover, Tag, notification } from 'antd';
@@ -46,8 +46,14 @@ export function JackettResultsTable({
     },
     {
       title: 'Name',
-      render: (row: JackettFormattedResult) =>
-        truncate(row.title, { length: 70 }),
+      ellipsis: {
+        showTitle: false,
+      },
+      render: (row: JackettFormattedResult) => (
+        <Popover content={row.title}>
+          {row.title}
+        </Popover>
+      ),
     },
     {
       title: 'Size',
@@ -209,6 +215,8 @@ function ManualDownloadMedia({
   return loading1 || loading2 || loading3 ? (
     <LoadingOutlined />
   ) : (
-    <DownloadOutlined style={{ cursor: 'pointer' }} onClick={handleClick} />
+    <Popover content={jackettResult.link}>
+      <DownloadOutlined style={{ cursor: 'pointer' }} onClick={handleClick} />
+    </Popover>
   );
 }


### PR DESCRIPTION
This PR adds two quality-of-life improvements to the Jackett results table.

### 1. Torrent Name

Use Ant table's `ellipsis` feature to perform dynamic truncation of the torrent name, instead of using a fixed truncation of 70 chars.
Additionally, a popover tooltip is added to show the full name on hover.

![dynamic_truncation_and_tooltip](https://user-images.githubusercontent.com/4683714/161648589-6017d7f6-1eac-45b3-ac22-869a79ba06ca.png)

### 2. Download Link

When manually selecting a torrent, it's often desirable to see where it's coming from. This adds a popover tooltip to the download button, containing the result link.

![download_tooltip](https://user-images.githubusercontent.com/4683714/161648676-fc903f1b-061d-44fc-a08b-f60b50d48470.png)

Open to feedback :)