### PR TITLE
Fix Healthchecks

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14-alpine
 
+RUN apk add curl
+
 ENV PORT 4000
 EXPOSE 4000
 
@@ -12,6 +14,6 @@ COPY . .
 RUN yarn build
 
 HEALTHCHECK --start-period=30s \
-  CMD curl -f http://localhost:4000/health || exit 1
+  CMD curl -s -f http://localhost:4000/health || exit 1
 
 CMD yarn start:prod

--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14-alpine
 
+RUN apk add curl
+
 ENV PORT 3000
 EXPOSE 3000
 
@@ -12,6 +14,6 @@ COPY . .
 RUN yarn build
 
 HEALTHCHECK --start-period=30s \
-  CMD curl -f http://localhost:3000 || exit 1
+  CMD curl -s -f http://localhost:3000 || exit 1
 
 CMD yarn start


### PR DESCRIPTION
Healthchecks currently fail because curl is not present in the node:14-alpine container by default.

```
$ docker inspect bobarr-api
{
    ...omittied...
    "State": {
    "Status": "running",
    ...omitted...
        "Health": {
            "Status": "unhealthy",
            "FailingStreak": 696,
            "Log": [{
                "Start": "2022-04-05T16:47:00.769414322+12:00",
                "End": "2022-04-05T16:47:00.815176505+12:00",
                "ExitCode": 1,
                "Output": "/bin/sh: curl: not found\n"
                },
```


This PR adds curl to the container to address this issue. The `-s` flag has also been added to curl to reduce chatter when viewing healthcheck output.