### PR TITLE
fix: Ensure Seasons are set to Processed on Library scan

### DIFF
--- a/packages/api/src/entities/dao/tvseason.dao.ts
+++ b/packages/api/src/entities/dao/tvseason.dao.ts
@@ -17,11 +17,16 @@ export class TVSeasonDAO extends Repository<TVSeason> {
     return match !== undefined;
   }
 
-  public async findOrCreate(seasonAttributes: {
-    tvShowId: number;
-    seasonNumber: number;
-  }, defaultState?: DownloadableMediaState) {
+  public async findOrCreate(
+    seasonAttributes: {
+      tvShowId: number;
+      seasonNumber: number;
+    },
+    defaultState?: DownloadableMediaState
+  ) {
     const match = await this.findOne(seasonAttributes);
-    return match || (await this.save({ ...seasonAttributes, state: defaultState }));
+    return (
+      match || (await this.save({ ...seasonAttributes, state: defaultState }))
+    );
   }
 }

--- a/packages/api/src/entities/dao/tvseason.dao.ts
+++ b/packages/api/src/entities/dao/tvseason.dao.ts
@@ -1,3 +1,4 @@
+import { DownloadableMediaState } from 'src/app.dto';
 import { EntityRepository, Repository } from 'typeorm';
 import { TVSeason } from '../tvseason.entity';
 
@@ -19,8 +20,8 @@ export class TVSeasonDAO extends Repository<TVSeason> {
   public async findOrCreate(seasonAttributes: {
     tvShowId: number;
     seasonNumber: number;
-  }) {
+  }, defaultState?: DownloadableMediaState) {
     const match = await this.findOne(seasonAttributes);
-    return match || (await this.save(seasonAttributes));
+    return match || (await this.save({ ...seasonAttributes, state: defaultState }));
   }
 }

--- a/packages/api/src/modules/jobs/processors/scan-library.processor.ts
+++ b/packages/api/src/modules/jobs/processors/scan-library.processor.ts
@@ -411,7 +411,7 @@ export class ScanLibraryProcessor {
       const tvSeason = await tvSeasonDAO.findOrCreate({
         tvShowId: tvShow!.id,
         seasonNumber: parseInt(seasonNumber, 10),
-      });
+      }, DownloadableMediaState.PROCESSED);
 
       const episode = await tvEpisodeDAO.findOrCreate({
         tvShowId: tvShow!.id,

--- a/packages/api/src/modules/jobs/processors/scan-library.processor.ts
+++ b/packages/api/src/modules/jobs/processors/scan-library.processor.ts
@@ -408,10 +408,13 @@ export class ScanLibraryProcessor {
         episodeNumber,
       });
 
-      const tvSeason = await tvSeasonDAO.findOrCreate({
-        tvShowId: tvShow!.id,
-        seasonNumber: parseInt(seasonNumber, 10),
-      }, DownloadableMediaState.PROCESSED);
+      const tvSeason = await tvSeasonDAO.findOrCreate(
+        {
+          tvShowId: tvShow!.id,
+          seasonNumber: parseInt(seasonNumber, 10),
+        },
+        DownloadableMediaState.PROCESSED
+      );
 
       const episode = await tvEpisodeDAO.findOrCreate({
         tvShowId: tvShow!.id,


### PR DESCRIPTION
#### The Problem

Currently, when existing TV Shows are imported by scan-library, every season gets stuck on "Searching", even though all files for that season are present:

![image](https://user-images.githubusercontent.com/4683714/161746684-3b4555f0-4ca7-4fa8-909f-f81461b49d22.png)

This is because when `tvEpisodeDAO.findOrCreate` is called, it defaults to the `SEARCHING` state:

https://github.com/iam4x/bobarr/blob/1f24631adcdb227819c5850b88a462d5d0b3125a/packages/api/src/modules/jobs/processors/scan-library.processor.ts#L411-L414

#### The Solution

This PR addresses the issue by setting the state of seasons created during the scan process to `PROCESSED`.
