### PR TITLE
Fix WEB_UI_API_URL

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -3,7 +3,6 @@
 /* eslint import/no-commonjs: off */
 
 module.exports = {
-  env: { WEB_UI_API_URL: process.env.WEB_UI_API_URL },
   webpackDevMiddleware: (config) => {
     // Solve compiling problem via vagrant
     config.watchOptions = {
@@ -11,6 +10,12 @@ module.exports = {
       aggregateTimeout: 300, // delay before rebuilding
     };
     return config;
+  },
+  publicRuntimeConfig: {
+    WEB_UI_API_URL: process.env.WEB_UI_API_URL
+  },
+  serverRuntimeConfig: {
+    WEB_UI_SSR_API_URL: process.env.WEB_UI_SSR_API_URL
   },
   async redirects() {
     return [

--- a/packages/web/utils/api-url.ts
+++ b/packages/web/utils/api-url.ts
@@ -1,2 +1,12 @@
-const host = typeof window === 'undefined' ? 'api' : window.location.hostname;
-export const apiURL = process.env.WEB_UI_API_URL || `http://${host}:4000`;
+import getConfig from 'next/config';
+
+const isServer = typeof window === 'undefined';
+
+const {
+  publicRuntimeConfig: { WEB_UI_API_URL },
+  serverRuntimeConfig: { WEB_UI_SSR_API_URL },
+} = getConfig();
+
+export const apiURL = isServer
+  ? WEB_UI_SSR_API_URL || 'http://api:4000'
+  : WEB_UI_API_URL || `http://${window.location.hostname}:4000`;


### PR DESCRIPTION
The current implementation for WEB_UI_API_URL doesn't work. This is because:
 - Environment variables in the frontend are added at buildtime, not runtime.
 - Environment variables aren't exported to the Next.js frontend, unless they start with NEXT_PUBLIC.

This PR fixes this issue by using [Next.js runtime configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) instead.